### PR TITLE
Just lowercasing this makes it work in linux with ruby and ruby dev tool...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ submodules:
 	git submodule update
 
 commandt:
-	cd bundle/Command-T/ruby/command-t/;\
+	cd bundle/command-t/ruby/command-t/;\
 		/usr/bin/ruby extconf.rb;\
 		make clean && make
 


### PR DESCRIPTION
...s installed, on Mint and Debian anyway, on mac cd commands aren't case sensitive
